### PR TITLE
Create-based views with setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A tiny web framework with mild ambitions. One file. No dependencies. No build st
 
 I don't want to spend 3 hours fiddling with JavaScript bundlers and build tools. It's 2023. The web platform is robust, JavaScript is a pretty good dynamic language, and modules exist. I want to `<script type="module" src="main.js">`, and hit refresh to see changes.
 
-Mild is a little library for just building web apps. You can use it to build a small SPA, or to build deterministic stand-alone components for an island architecture.
+Mild is a little library for building web apps. You can use it to build a small SPA, or to build deterministic stand-alone components for an island architecture.
 
 ## Installing
 
@@ -94,7 +94,7 @@ const heading = view({
 `view()` takes these functions and returns an object with:
 
 - `view.create()` - creates the element
-- `view.render(element, state)` - renders it, but only if the state has changed
+- `view.render(element, state)` - renders element, but only if the state has changed
 
 ```js
 // Create an element. This runs both setup and render.

--- a/examples/counter/app.js
+++ b/examples/counter/app.js
@@ -2,8 +2,8 @@ import {
   Store,
   next,
   view,
-  mounting,
-  $
+  $,
+  h
 } from '../../mild.js'
 
 // All state changes are expressed in terms of actions sent to a store
@@ -12,19 +12,16 @@ action.increment = {type: 'increment'}
 
 // A view describes how to create and update (render) an element.
 const appView = view({
-  setup: (el, state, send) => {
-    el.className = 'container'
-    let textEl = document.createElement('div')
-    textEl.className = 'text'
-    el.append(textEl)
-
-    let buttonEl = document.createElement('button')
-    buttonEl.className = 'text'
-    buttonEl.onclick = event => send(action.increment)
-    buttonEl.textContent = 'Click to increment'
-    el.append(buttonEl)
-  },
+  create: () => h(
+    'div',
+    {className: 'container'},
+    h('div', {className: 'text'}),
+    h('button', {className: 'button'}, 'Click to increment')
+  ),
   render: (el, state, send) => {
+    let buttonEl = $(el, '.button')
+    buttonEl.onclick = event => send(action.increment)
+
     let textEl = $(el, '.text')
     textEl.textContent = state.count
   }
@@ -50,8 +47,8 @@ let body = $(document, 'body')
 
 // Initialize store
 let store = new Store({
-  target: body,
-  render: mounting(appView),
+  mount: body,
   init,
-  update
+  update,
+  ...appView
 })

--- a/examples/counter/app.js
+++ b/examples/counter/app.js
@@ -11,7 +11,7 @@ const action = {}
 action.increment = {type: 'increment'}
 
 // A view describes how to create and update (render) an element.
-const appView = view({
+const app = view({
   create: () => h(
     'div',
     {className: 'container'},
@@ -27,16 +27,16 @@ const appView = view({
   }
 })
 
-const appModel = ({count}) => ({count})
+app.model = ({count}) => ({count})
 
 // Create initial state transaction
-const init = () => next(appModel({count: 0}))
+app.init = () => next(app.model({count: 0}))
 
 // Given previous state and an action, creates new state transactions.
-const update = (state, action) => {
+app.update = (state, action) => {
   switch (action.type) {
   case 'increment':
-    return next(appModel({...state, count: state.count + 1}))
+    return next(app.model({...state, count: state.count + 1}))
   default:
     console.warn("Unhandled action type", action)
     return next(state)
@@ -48,7 +48,5 @@ let body = $(document, 'body')
 // Initialize store
 let store = new Store({
   mount: body,
-  init,
-  update,
-  ...appView
+  ...app
 })

--- a/mild.js
+++ b/mild.js
@@ -78,17 +78,20 @@ export class Store {
 
   /**
    * @param {object} options
-   * @param {HTMLElement} options.target - the host element on which to mount the store-managed element
-   * @param {Rendering<HTMLElement, State, Action>} options.render - the view to render
+   * @param {HTMLElement} options.mount - the host element on which to mount the store-managed element
+   * @param {() => Target} options.create - the view to render
+   * @param {Rendering<Target, State, Action>} options.render - the view to render
    * @param {() => Transaction<State, Action>} options.init - a function to initialize the store
    * @param {(state: State, action: Action) => Transaction<State, Action>} options.update - an update function for producing transactions
    */
-  constructor({target, init, update, render}) {
+  constructor({mount, init, update, create, render}) {
     this.#render = render
     this.#update = update
-    this.#target = target
     let {state, effects} = init()
     this.#state = state
+    let target = create()
+    this.#target = target
+    mount.replaceChildren(target)
     render(target, state, this.send)
     this.runAll(effects)
   }

--- a/mild.js
+++ b/mild.js
@@ -280,7 +280,7 @@ export const view = ({
   create,
   render
 }) => ({
-  create: cloning(create),
+  create,
   render: rendering(render)
 })
 

--- a/mild.js
+++ b/mild.js
@@ -498,8 +498,8 @@ export const h = (
   let element = document.createElement(tag)
 
   const {
-    styles,
-    dataset,
+    styles={},
+    dataset={},
     ...ordinaryProps
   } = props
 


### PR DESCRIPTION
Updates the view approach.

- view `create` takes a zero-parameter factory function who's job is to construct a DOM tree
  - This takes care of the majority of initial scaffolding use-cases, including assigning classes, creating shadow roots, etc.
  - The only thing it doesn't have access to is state. This is deliberate. DOM takes the approach of constructing without state, and then assigning state to properties after construction. Web Component constructors also take no arguments, and don't have access to most user-assigned attributes or property values yet, since they haven't had a chance to be set. By mirroring this approach, we make it easier to integrate views with web components.
- render still takes an optional `setup` parameter that can be used to do additional one-time setup that requires access to `state` or `send`. This is unusual, though, so it's optional.
- `h()` gives you hyperscript-style element construction
- an optional `cloning()` decorator lets you optimize `create()` for efficiency.
  - however, we don't apply it by default, since `cloneNode(true)` does not clone shadow roots.

Also removes tagging from `list()`. This is something child components can define themselves.

The upshot is that we have an API that feels pretty expressive, and integrates pretty well with components as well.

For example:

```js
import {view} from './vendor/mild.js'

export class ViewElement extends HTMLElement {
  static styles() {
    return []
  }

  static shadow() {
    throw new Error('Not implemented')
  }

  constructor() {
    super()
    this.attachShadow({mode: 'open'})
    this.shadowRoot.adoptedStyleSheets = this.constructor.styles()
    let fragment = this.constructor.shadow()
    this.shadowRoot.append(fragment)
  }
}

const noStyles = () => []
const noShadow = () => new DocumentFragment()
const noOp = () => {}

export const element = ({
  tag,
  styles=noStyles,
  shadow=noShadow,
  setup=noOp,
  render=noOp
}) => {
  class CustomViewElement extends ViewElement {
    static shadow = shadow
    static styles = styles
  }
  customElements.define(tag, CustomViewElement)

  return view({
    create: () => document.createElement(tag),
    render: rendering({setup, render})
  })
}
```